### PR TITLE
Add date field to todos

### DIFF
--- a/app/models/todo.py
+++ b/app/models/todo.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Date
 from sqlalchemy.sql import func
+from sqlalchemy.ext.hybrid import hybrid_property
 from app.database.database import Base
 
 class Todo(Base):
@@ -11,3 +12,8 @@ class Todo(Base):
     completed = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+    date = Column(Date, server_default=func.current_date())
+    
+    @hybrid_property
+    def creation_date(self):
+        return self.created_at.date() if self.created_at else None

--- a/app/schemas/todo.py
+++ b/app/schemas/todo.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, ConfigDict
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional
 
 class TodoBase(BaseModel):
@@ -21,3 +21,4 @@ class Todo(TodoBase):
     id: int
     created_at: datetime
     updated_at: Optional[datetime]
+    date: date

--- a/tests/test_todos.py
+++ b/tests/test_todos.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
+from datetime import date
 
 def test_read_root(client: TestClient):
     response = client.get("/")
@@ -20,6 +21,8 @@ def test_create_todo(client: TestClient):
     assert data["completed"] == todo_data["completed"]
     assert "id" in data
     assert "created_at" in data
+    assert "date" in data
+    assert data["date"] == str(date.today())
 
 def test_get_todos(client: TestClient):
     # Create a todo first
@@ -32,6 +35,8 @@ def test_get_todos(client: TestClient):
     assert isinstance(todos, list)
     assert len(todos) == 1
     assert todos[0]["title"] == "Test Todo"
+    assert "date" in todos[0]
+    assert todos[0]["date"] == str(date.today())
 
 def test_get_todo_by_id(client: TestClient):
     # Create a todo
@@ -45,6 +50,8 @@ def test_get_todo_by_id(client: TestClient):
     data = response.json()
     assert data["id"] == todo_id
     assert data["title"] == "Test Todo"
+    assert "date" in data
+    assert data["date"] == str(date.today())
 
 def test_get_todo_not_found(client: TestClient):
     response = client.get("/api/todos/9999")


### PR DESCRIPTION
## Summary
- Add date column to Todo model that automatically stores the creation date
- Update Pydantic schemas to include the date field in API responses
- Add comprehensive tests to verify the date field functionality

## Changes
- Added \ column with \ default to Todo model
- Added \ hybrid property for date extraction from created_at
- Updated Todo schema to include date field
- Updated tests to verify date field is present and has correct value

## Test Results
All 9 tests pass successfully with the new date field included.

The date field allows for easier filtering and grouping of todos by creation date.